### PR TITLE
v1.29.0: fix Tray 1 underwatering — rain-sensor debounce + sustained-wet confirmation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,5 +37,26 @@ Recent history follows short, imperative, version-prefixed subjects such as `v1.
 ## Security & Configuration Tips
 Do not commit secrets. Local credentials and tokens belong in `include/secret.h`. Treat LittleFS contents and Telegram/MQTT settings as deployable configuration, and double-check proxy/service files in `deploy/systemd/` before shipping monitoring changes.
 
+## Debugging via Monitoring Logs (Loki)
+
+The live device ships logs (and metrics) to the monitoring box's Loki via the metrics proxy. This is the primary way to debug field behavior without serial access. Reach for it before guessing.
+
+**Tool:** `~/Documents/projects/personal-os/tools/waterlog` (wraps the fleet `mon` ssh; built 2026-06-30). Modes:
+- `waterlog summary [days]` — per-tray multiplier / last-fill / cycle-count / timeout table + tank events. **Start here.**
+- `waterlog tray N [days]` — every line for Tray N (does the index math for you).
+- `waterlog timeouts [days]` / `waterlog recent [min]` / `waterlog grep 'REGEX' [days]`.
+
+Loki labels: `{job="esp32", device="watering-system"}`. (Prometheus metric selector was unverified as of 2026-06-30 — trust the logs.)
+
+**Two traps that will bite you:**
+1. **Indexing.** A log line `Valve N` = internal `valveIndex N` = the user's **`Tray N+1`**. Session-tracking lines (`Tray M`) and Telegram alerts use `M = valveIndex+1`. So the user's *Tray 1* is log *Valve 0*. `waterlog tray N` already maps this; the raw logs do not.
+2. **Loki 429s on filtered queries.** A server-side `|=`/`|~` filter over a multi-day range splits into hundreds of subqueries → `429 "too many outstanding requests"` (surfaces as a python JSON-decode error in `lokiq logs`). **Pull label-only and filter client-side** — that's exactly what `waterlog` does (label-only query + python regex + retry-on-429). Don't add line filters to long-range server queries.
+
+**The underwatering signature (learning runaway), how to read it:**
+- `waterlog summary` → any tray with `mult` >> 1.0× is under-watering (1.0× = 24 h; the cap is `MAX_INTERVAL_MULTIPLIER`). The whole fleet drifting >1.0× = the asymmetric grow-vs-shrink loop; one tray pinned near the cap = that sensor.
+- In `waterlog tray N`, the tell is a cycle that **completes `✓ OK` while every `Sensor N-1 GPIO …` line in the trace reads `(DRY)`**, with `learning: fill=…s interval A→B` where B > A and `fill` shrinking over cycles. That means a brief WET flicker (caught by the 100 ms rain check, missed by the 5 s debug log) ended the cycle and was recorded as a real fill → interval grows → tray waters less, shorter, each time. Root cause was an **un-debounced** `readRainSensor`; fixed in v1.28.0 (5-of-7 majority). Manual `/api/water` cycles also feed learning, so a fast false-complete on a manual top-up *raises* the interval.
+- TIMEOUT events (`waterlog timeouts`) are the *opposite* state: pump ran the full per-valve window, sensor never wetted → interval decrements. Genuine slow-flow/clog looks like repeated timeouts on one valve.
+- Also check tank state: `water level before: X% (empty)` / `WATER LEVEL LOW` blocks watering fleet-wide — a low tank under-waters everything regardless of learning.
+
 ## Plan Execution
 When a written implementation plan is ready (e.g. under `docs/superpowers/plans/`), execute it via **subagent-driven development** (`superpowers:subagent-driven-development`) by default — fresh subagent per task with review between tasks. Do not ask which execution mode to use unless the user explicitly requests inline execution.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,8 +5,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ESP32-S3 smart watering system: 6 valves, 6 rain sensors, 1 pump, 1 plant lamp. Time-based learning, Telegram notifications, web interface.
 
 **Stack**: ESP32-S3-N8R2, LittleFS, ArduinoJson 6.21.0, DS3231 RTC (GPIO 14/3), Adafruit NeoPixel
-**Version**: 1.28.0 (config.h:10)
-**Testing**: 57 native unit tests (desktop, no hardware)
+**Version**: 1.29.0 (config.h:10)
+**Testing**: 60 native unit tests (desktop, no hardware)
 
 ## Build & Deploy
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,8 +5,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ESP32-S3 smart watering system: 6 valves, 6 rain sensors, 1 pump, 1 plant lamp. Time-based learning, Telegram notifications, web interface.
 
 **Stack**: ESP32-S3-N8R2, LittleFS, ArduinoJson 6.21.0, DS3231 RTC (GPIO 14/3), Adafruit NeoPixel
-**Version**: 1.27.0 (config.h:10)
-**Testing**: 53 native unit tests (desktop, no hardware)
+**Version**: 1.28.0 (config.h:10)
+**Testing**: 57 native unit tests (desktop, no hardware)
 
 ## Build & Deploy
 

--- a/include/SensorDebounce.h
+++ b/include/SensorDebounce.h
@@ -1,0 +1,23 @@
+#ifndef SENSOR_DEBOUNCE_H
+#define SENSOR_DEBOUNCE_H
+
+// Pure, hardware-free debounce decision shared by the firmware and the native
+// test suite. Rain/soil sensors are active-LOW (LOW = wet).
+//
+// A single stray LOW reading -- EMI from pump/valve switching, condensation, a
+// momentary contact -- must NOT be taken as "wet". Reading one spike as wet both
+// cuts a watering cycle short (under-fill) and can trip the "tray already full
+// -> 2x interval" learning path, which is how one tray's learned interval runs
+// away to the cap and that tray ends up heavily under-watered. We therefore
+// sample the pin N times and only declare "wet" when at least `threshold` of
+// those samples were LOW (e.g. 5 of 7), mirroring the master overflow sensor.
+namespace SensorDebounce {
+
+// Decide "wet" from the number of LOW (wet) samples counted in a sample window.
+inline bool isWet(int lowReadings, int threshold) {
+  return lowReadings >= threshold;
+}
+
+}  // namespace SensorDebounce
+
+#endif  // SENSOR_DEBOUNCE_H

--- a/include/SensorDebounce.h
+++ b/include/SensorDebounce.h
@@ -18,6 +18,16 @@ inline bool isWet(int lowReadings, int threshold) {
   return lowReadings >= threshold;
 }
 
+// Sustained-wet confirmation across watering polls. Debounce (above) rejects a
+// single noisy SAMPLE; this rejects a single noisy READ. A fill only completes
+// after `required` consecutive wet reads (each ~RAIN_CHECK_INTERVAL apart), so a
+// brief mid-cycle flicker can't end watering early and be logged as a real fill
+// — the field failure that ran tray intervals away. Mirrors the overflow
+// sensor's CONFIRMATION_CHECKS. A wet read grows the streak; any dry read resets
+// it to 0.
+inline int nextWetStreak(int streak, bool wet) { return wet ? streak + 1 : 0; }
+inline bool fillConfirmed(int streak, int required) { return streak >= required; }
+
 }  // namespace SensorDebounce
 
 #endif  // SENSOR_DEBOUNCE_H

--- a/include/TestConfig.h
+++ b/include/TestConfig.h
@@ -46,6 +46,11 @@ inline unsigned long getValveEmergencyTimeout(int valveIndex) {
 
 static const unsigned long SENSOR_POWER_STABILIZATION = 100;
 
+// Rain/soil sensor debouncing (mirror production config.h)
+static const int RAIN_SENSOR_DEBOUNCE_SAMPLES = 7;
+static const int RAIN_SENSOR_DEBOUNCE_THRESHOLD = 5;
+static const unsigned long RAIN_SENSOR_DEBOUNCE_DELAY_MS = 5;
+
 // ============================================
 // Learning Algorithm Constants for Testing
 // ============================================
@@ -55,7 +60,7 @@ static const int LEARNING_MAX_SKIP_CYCLES = 15;
 static const int LEARNING_FULL_SKIP_CYCLES = 10;
 static const unsigned long AUTO_WATERING_MIN_INTERVAL_MS = 86400000;
 static const unsigned long UNCALIBRATED_RETRY_INTERVAL_MS = 86400000;
-static const float MAX_INTERVAL_MULTIPLIER = 5.0;
+static const float MAX_INTERVAL_MULTIPLIER = 2.5;
 
 // ============================================
 // Plant Light Constants for Testing

--- a/include/TestConfig.h
+++ b/include/TestConfig.h
@@ -50,6 +50,7 @@ static const unsigned long SENSOR_POWER_STABILIZATION = 100;
 static const int RAIN_SENSOR_DEBOUNCE_SAMPLES = 7;
 static const int RAIN_SENSOR_DEBOUNCE_THRESHOLD = 5;
 static const unsigned long RAIN_SENSOR_DEBOUNCE_DELAY_MS = 5;
+static const int RAIN_SENSOR_CONFIRMATION_CHECKS = 3;
 
 // ============================================
 // Learning Algorithm Constants for Testing
@@ -60,7 +61,7 @@ static const int LEARNING_MAX_SKIP_CYCLES = 15;
 static const int LEARNING_FULL_SKIP_CYCLES = 10;
 static const unsigned long AUTO_WATERING_MIN_INTERVAL_MS = 86400000;
 static const unsigned long UNCALIBRATED_RETRY_INTERVAL_MS = 86400000;
-static const float MAX_INTERVAL_MULTIPLIER = 2.5;
+static const float MAX_INTERVAL_MULTIPLIER = 5.0;
 
 // ============================================
 // Plant Light Constants for Testing

--- a/include/ValveController.h
+++ b/include/ValveController.h
@@ -76,6 +76,12 @@ struct ValveController {
   // wrong direction.
   bool lastCycleWasTimeoutRecovery;
 
+  // Consecutive wet sensor reads during PHASE_WATERING. A fill only completes
+  // after RAIN_SENSOR_CONFIRMATION_CHECKS back-to-back wet reads, so a brief
+  // mid-cycle flicker can't end watering early and be recorded as a real fill.
+  // Reset to 0 when watering starts and on any dry read.
+  int rainWetStreak;
+
   // Long outage recovery: Real time since last watering when millis() can't represent timestamp
   unsigned long realTimeSinceLastWatering; // Duration in ms, calculated during load
                                            // Used when lastWateringCompleteTime == 0 after long outage
@@ -91,7 +97,7 @@ struct ValveController {
         previousFillDuration(0), lastWaterLevelPercent(0.0),
         isCalibrated(false), totalWateringCycles(0), consecutiveTimeouts(0),
         autoWateringEnabled(true), intervalMultiplier(1.0),
-        lastCycleWasTimeoutRecovery(false),
+        lastCycleWasTimeoutRecovery(false), rainWetStreak(0),
         realTimeSinceLastWatering(0), realTimeSinceLastWateringAttempt(0) {}
 };
 

--- a/include/WateringSystem.h
+++ b/include/WateringSystem.h
@@ -9,6 +9,7 @@
 #include "config.h"
 #include "DS3231RTC.h"
 #include "LearningAlgorithm.h"
+#include "SensorDebounce.h"
 #include <Adafruit_NeoPixel.h>
 #include <Arduino.h>
 #include <ArduinoJson.h>
@@ -1494,8 +1495,23 @@ inline bool WateringSystem::readRainSensor(int valveIndex) {
     delay(SENSOR_POWER_STABILIZATION);
   }
 
-  // Read sensor: LOW = wet, HIGH = dry (with pull-up)
-  int rawValue = digitalRead(RAIN_SENSOR_PINS[valveIndex]);
+  // Read sensor with software debounce: LOW = wet, HIGH = dry (with pull-up).
+  // A single stray LOW (EMI from pump/valve switching, condensation, a momentary
+  // contact) must NOT be read as "wet": a false wet both under-fills the tray
+  // (the watering cycle ends early) and feeds the "tray already full -> grow
+  // interval" learning runaway that starves one tray. Mirror the master overflow
+  // sensor — take N samples and require a majority LOW. GPIO 18 stays powered for
+  // the whole sampling window.
+  int lowReadings = 0;
+  for (int i = 0; i < RAIN_SENSOR_DEBOUNCE_SAMPLES; i++) {
+    if (digitalRead(RAIN_SENSOR_PINS[valveIndex]) == LOW) {
+      lowReadings++;
+    }
+    if (i < RAIN_SENSOR_DEBOUNCE_SAMPLES - 1) {
+      delay(RAIN_SENSOR_DEBOUNCE_DELAY_MS);
+    }
+  }
+  bool wet = SensorDebounce::isWet(lowReadings, RAIN_SENSOR_DEBOUNCE_THRESHOLD);
 
   // Power management: Only turn off GPIO 18 if NOT in watering phase
   // During watering, GPIO 18 stays HIGH for continuous sensor monitoring
@@ -1507,12 +1523,13 @@ inline bool WateringSystem::readRainSensor(int valveIndex) {
   static unsigned long lastDetailedLog = 0;
   if (millis() - lastDetailedLog > 5000) {  // Detailed log every 5s
     DebugHelper::debug("Sensor " + String(valveIndex) + " GPIO " + String(RAIN_SENSOR_PINS[valveIndex]) +
-                      ": raw=" + String(rawValue) + " (" + String(rawValue == LOW ? "WET" : "DRY") +
+                      ": " + String(lowReadings) + "/" + String(RAIN_SENSOR_DEBOUNCE_SAMPLES) +
+                      " LOW (" + String(wet ? "WET" : "DRY") +
                       "), GPIO18=" + String(anyWatering ? "CONTINUOUS" : "PULSED"));
     lastDetailedLog = millis();
   }
 
-  return (rawValue == LOW); // LOW = wet/rain detected
+  return wet; // majority LOW = wet/rain detected
 }
 
 inline void WateringSystem::openValve(int valveIndex) {
@@ -1597,7 +1614,10 @@ inline void WateringSystem::processLearningData(ValveController *valve,
   const long FILL_STABLE_TOLERANCE_MS =
       500; // ±0.5s - threshold for "same fill time"
   const float MIN_INTERVAL_MULTIPLIER = 1.0; // Never go below 24h
-  const float INTERVAL_DOUBLE = 2.0;         // Double when tray already full
+  // Growth factor when a tray reads "already full" before watering. Softened
+  // 2.0→1.5 (tray-1 fix) so one mistaken "full" reading can't double the wait;
+  // combined with sensor debounce this stops the interval running away.
+  const float INTERVAL_DOUBLE = 1.5;         // Grow when tray already full
   const float INTERVAL_INCREMENT_LARGE =
       1.0; // Large adjustment for coarse search
   const float INTERVAL_DECREMENT_BINARY =

--- a/include/WateringSystem.h
+++ b/include/WateringSystem.h
@@ -1614,10 +1614,7 @@ inline void WateringSystem::processLearningData(ValveController *valve,
   const long FILL_STABLE_TOLERANCE_MS =
       500; // ±0.5s - threshold for "same fill time"
   const float MIN_INTERVAL_MULTIPLIER = 1.0; // Never go below 24h
-  // Growth factor when a tray reads "already full" before watering. Softened
-  // 2.0→1.5 (tray-1 fix) so one mistaken "full" reading can't double the wait;
-  // combined with sensor debounce this stops the interval running away.
-  const float INTERVAL_DOUBLE = 1.5;         // Grow when tray already full
+  const float INTERVAL_DOUBLE = 2.0;         // Double when tray already full
   const float INTERVAL_INCREMENT_LARGE =
       1.0; // Large adjustment for coarse search
   const float INTERVAL_DECREMENT_BINARY =

--- a/include/WateringSystemStateMachine.h
+++ b/include/WateringSystemStateMachine.h
@@ -28,6 +28,7 @@ inline void WateringSystem::processValve(int valveIndex, unsigned long currentTi
             if (currentTime - valve->valveOpenTime >= VALVE_STABILIZATION_DELAY) {
                 valve->phase = PHASE_CHECKING_INITIAL_RAIN;
                 valve->lastRainCheck = currentTime;
+                valve->rainWetStreak = 0;  // fresh streak for the initial already-full check
                 DebugHelper::debug("Step 2: Checking rain sensor (water is flowing now)...");
             }
             break;
@@ -39,7 +40,16 @@ inline void WateringSystem::processValve(int valveIndex, unsigned long currentTi
                 valve->rainDetected = isRaining;
 
                 if (isRaining) {
-                    // Sensor already wet = TRAY IS FULL - treat as successful fill
+                    // Require SUSTAINED wet here too: a single (debounced) wet read at
+                    // cycle start must not conclude "already full" and ×2 the interval.
+                    // Need RAIN_SENSOR_CONFIRMATION_CHECKS consecutive wet reads; a dry
+                    // read (else-branch) resets the streak and proceeds to water.
+                    valve->rainWetStreak = SensorDebounce::nextWetStreak(valve->rainWetStreak, true);
+                    if (!SensorDebounce::fillConfirmed(valve->rainWetStreak, RAIN_SENSOR_CONFIRMATION_CHECKS)) {
+                        break;  // not yet confirmed full — re-check next poll before skipping
+                    }
+
+                    // Sensor sustained wet = TRAY IS FULL - treat as successful fill
                     DebugHelper::debug("✓ Sensor " + String(valveIndex) + " already WET - tray is FULL");
                     if (g_metricsLog) g_metricsLog("info", "Valve " + String(valveIndex) + ": rain=WET");
 
@@ -73,6 +83,7 @@ inline void WateringSystem::processValve(int valveIndex, unsigned long currentTi
                     }
                     valve->wateringStartTime = currentTime;
                     valve->timeoutOccurred = false;
+                    valve->rainWetStreak = 0;  // start sustained-wet confirmation fresh
                     valve->phase = PHASE_WATERING;
                     updatePumpState();
                     publishStateChange("valve" + String(valveIndex), "watering_started");
@@ -126,6 +137,17 @@ inline void WateringSystem::processValve(int valveIndex, unsigned long currentTi
                 }
 
                 if (isRaining) {
+                    // Require SUSTAINED wet before declaring the fill complete:
+                    // RAIN_SENSOR_CONFIRMATION_CHECKS consecutive wet reads. Debounce
+                    // rejects a noisy sample; this rejects a single noisy read — so a
+                    // brief mid-cycle flicker can't end watering early and be logged as
+                    // a real fill (the field cause of the tray-interval runaway). A dry
+                    // read in the else-branch resets the streak.
+                    valve->rainWetStreak = SensorDebounce::nextWetStreak(valve->rainWetStreak, true);
+                    if (!SensorDebounce::fillConfirmed(valve->rainWetStreak, RAIN_SENSOR_CONFIRMATION_CHECKS)) {
+                        break;  // not yet confirmed — keep watering, re-check next poll
+                    }
+
                     // SAFETY: Sensor detected water - immediately close valve and stop pump
                     // Calculate FULL cycle time: from valve open to valve close
                     int totalTime = (currentTime - valve->valveOpenTime) / 1000;
@@ -158,30 +180,36 @@ inline void WateringSystem::processValve(int valveIndex, unsigned long currentTi
 
                     publishStateChange("valve" + String(valveIndex), "watering_complete");
                     valve->phase = PHASE_CLOSING_VALVE;  // Go to cleanup phase for learning data
-                } else if (!valve->wateringRequested) {
-                    // Manual stop requested - immediately close valve and stop pump
-                    DebugHelper::debug("⚠️ Manual stop for valve " + String(valveIndex) + " - IMMEDIATE STOP");
+                } else {
+                    // Dry read — break the consecutive-wet streak so confirmation
+                    // restarts from scratch the next time the sensor reads wet.
+                    valve->rainWetStreak = 0;
 
-                    // SAFETY: Immediately close valve and stop pump
-                    closeValve(valveIndex);
-                    updatePumpState();
+                    if (!valve->wateringRequested) {
+                        // Manual stop requested - immediately close valve and stop pump
+                        DebugHelper::debug("⚠️ Manual stop for valve " + String(valveIndex) + " - IMMEDIATE STOP");
 
-                    valve->phase = PHASE_IDLE;  // Go directly to IDLE (no learning data for manual stop)
-                    valve->wateringRequested = false;
-                    valve->wateringStartTime = 0;  // Reset for next watering cycle
+                        // SAFETY: Immediately close valve and stop pump
+                        closeValve(valveIndex);
+                        updatePumpState();
 
-                    // CRITICAL: Turn off sensor power (GPIO 18) if no other valves are watering
-                    {
-                        bool anyWateringStop = false;
-                        for (int i = 0; i < NUM_VALVES; i++) {
-                            if (valves[i]->phase == PHASE_WATERING) {
-                                anyWateringStop = true;
-                                break;
+                        valve->phase = PHASE_IDLE;  // Go directly to IDLE (no learning data for manual stop)
+                        valve->wateringRequested = false;
+                        valve->wateringStartTime = 0;  // Reset for next watering cycle
+
+                        // CRITICAL: Turn off sensor power (GPIO 18) if no other valves are watering
+                        {
+                            bool anyWateringStop = false;
+                            for (int i = 0; i < NUM_VALVES; i++) {
+                                if (valves[i]->phase == PHASE_WATERING) {
+                                    anyWateringStop = true;
+                                    break;
+                                }
                             }
-                        }
-                        if (!anyWateringStop) {
-                            digitalWrite(RAIN_SENSOR_POWER_PIN, LOW);
-                            DebugHelper::debug("Sensor power (GPIO 18) turned OFF - no valves watering");
+                            if (!anyWateringStop) {
+                                digitalWrite(RAIN_SENSOR_POWER_PIN, LOW);
+                                DebugHelper::debug("Sensor power (GPIO 18) turned OFF - no valves watering");
+                            }
                         }
                     }
                 }

--- a/include/config.h
+++ b/include/config.h
@@ -7,7 +7,7 @@
 // ============================================
 // Device Configuration
 // ============================================
-const char *VERSION = "watering_system_1.27.0";
+const char *VERSION = "watering_system_1.28.0";
 const char *DEVICE_TYPE = "smart_watering_system_time_based";
 
 // ============================================
@@ -143,6 +143,17 @@ const unsigned long OVERFLOW_DEBOUNCE_DELAY_MS = 5; // Delay between readings (5
 const int OVERFLOW_CONFIRMATION_CHECKS = 3;     // Require 3 consecutive debounced detections (~300ms sustained LOW)
 
 // ============================================
+// Rain/Soil Sensor Debouncing Constants
+// ============================================
+// Rain sensors are active-LOW (LOW = wet). Debounce the same way as the overflow
+// sensor so a single stray LOW (EMI, condensation, momentary contact) cannot be
+// read as "wet" -- a false wet both under-fills the tray (cycle ends early) and
+// drives the "tray already full -> grow interval" learning runaway.
+const int RAIN_SENSOR_DEBOUNCE_SAMPLES = 7;            // Readings per sensor poll
+const int RAIN_SENSOR_DEBOUNCE_THRESHOLD = 5;          // Minimum LOW readings to declare wet (5 of 7)
+const unsigned long RAIN_SENSOR_DEBOUNCE_DELAY_MS = 5; // Delay between readings (5ms)
+
+// ============================================
 // Learning Algorithm Constants
 // ============================================
 const float LEARNING_EMPTY_THRESHOLD =
@@ -158,8 +169,11 @@ const unsigned long AUTO_WATERING_MIN_INTERVAL_MS =
 // "tray-still-full → 2x" and "fill > baseline → +1.0x" paths can compound
 // unboundedly when measurements are noisy (sensor placement, weather, etc.).
 // Empirically every TIMEOUT we saw happened with a multiplier in the 4.75x–7x
-// range; 5.0x is the safety belt — the algorithm fix does the real work.
-const float MAX_INTERVAL_MULTIPLIER = 5.0; // Never wait more than 5 days
+// range; the cap is the safety belt — the algorithm fix does the real work.
+// Lowered 5.0→2.5 (tray-1 fix): a 5-day starve is too long even as a worst
+// case, and a lower cap auto-rescues any runaway value loaded from flash on the
+// first boot of new firmware (clampMultiplier is applied to loaded values).
+const float MAX_INTERVAL_MULTIPLIER = 2.5; // Never wait more than 2.5 days
 const unsigned long UNCALIBRATED_RETRY_INTERVAL_MS =
     86400000; // 24 hours retry for uncalibrated trays found full
 const unsigned long RECENT_WATERING_THRESHOLD_MS =

--- a/include/config.h
+++ b/include/config.h
@@ -7,7 +7,7 @@
 // ============================================
 // Device Configuration
 // ============================================
-const char *VERSION = "watering_system_1.28.0";
+const char *VERSION = "watering_system_1.29.0";
 const char *DEVICE_TYPE = "smart_watering_system_time_based";
 
 // ============================================
@@ -152,6 +152,10 @@ const int OVERFLOW_CONFIRMATION_CHECKS = 3;     // Require 3 consecutive debounc
 const int RAIN_SENSOR_DEBOUNCE_SAMPLES = 7;            // Readings per sensor poll
 const int RAIN_SENSOR_DEBOUNCE_THRESHOLD = 5;          // Minimum LOW readings to declare wet (5 of 7)
 const unsigned long RAIN_SENSOR_DEBOUNCE_DELAY_MS = 5; // Delay between readings (5ms)
+// A fill completes only after this many CONSECUTIVE wet reads (~RAIN_CHECK_INTERVAL
+// apart). Debounce rejects a noisy sample; this rejects a noisy read — so a brief
+// mid-cycle flicker can't end watering early and be recorded as a real fill.
+const int RAIN_SENSOR_CONFIRMATION_CHECKS = 3;         // ~300ms sustained wet to confirm
 
 // ============================================
 // Learning Algorithm Constants
@@ -169,11 +173,12 @@ const unsigned long AUTO_WATERING_MIN_INTERVAL_MS =
 // "tray-still-full → 2x" and "fill > baseline → +1.0x" paths can compound
 // unboundedly when measurements are noisy (sensor placement, weather, etc.).
 // Empirically every TIMEOUT we saw happened with a multiplier in the 4.75x–7x
-// range; the cap is the safety belt — the algorithm fix does the real work.
-// Lowered 5.0→2.5 (tray-1 fix): a 5-day starve is too long even as a worst
-// case, and a lower cap auto-rescues any runaway value loaded from flash on the
-// first boot of new firmware (clampMultiplier is applied to loaded values).
-const float MAX_INTERVAL_MULTIPLIER = 2.5; // Never wait more than 2.5 days
+// range; 5.0x is the safety belt — the algorithm fix (debounce + sustained-wet
+// confirmation) does the real work. Kept at 5.0 deliberately: trays 2-6 are
+// healthy watering every 2-4.5 days, so a lower cap would force them to water
+// more often than they need. (clampMultiplier still rescues any value loaded
+// from flash that exceeds this.)
+const float MAX_INTERVAL_MULTIPLIER = 5.0; // Never wait more than 5 days
 const unsigned long UNCALIBRATED_RETRY_INTERVAL_MS =
     86400000; // 24 hours retry for uncalibrated trays found full
 const unsigned long RECENT_WATERING_THRESHOLD_MS =

--- a/test/test_native_all.cpp
+++ b/test/test_native_all.cpp
@@ -259,7 +259,7 @@ void test_clamp_multiplier_below_min_clamps_to_one(void) {
 
 void test_clamp_multiplier_above_max_clamps_to_cap(void) {
     // Trays we actually observed in the wild (6.5x, 7.0x) and the
-    // post-doubling worst case must all clamp to MAX_INTERVAL_MULTIPLIER (2.5).
+    // post-doubling worst case must all clamp to MAX_INTERVAL_MULTIPLIER (5.0).
     TEST_ASSERT_EQUAL_FLOAT(MAX_INTERVAL_MULTIPLIER,
         LearningAlgorithm::clampMultiplier(6.5f));
     TEST_ASSERT_EQUAL_FLOAT(MAX_INTERVAL_MULTIPLIER,
@@ -269,11 +269,11 @@ void test_clamp_multiplier_above_max_clamps_to_cap(void) {
 }
 
 void test_decrement_on_timeout_subtracts_quarter(void) {
-    // Calibrated valve at 2.50x hits TIMEOUT → 2.25x.
-    TEST_ASSERT_EQUAL_FLOAT(2.25f,
-        LearningAlgorithm::decrementMultiplierOnTimeout(2.5f));
-    TEST_ASSERT_EQUAL_FLOAT(1.75f,
-        LearningAlgorithm::decrementMultiplierOnTimeout(2.0f));
+    // Calibrated valve at 5.00x hits TIMEOUT → 4.75x.
+    TEST_ASSERT_EQUAL_FLOAT(4.75f,
+        LearningAlgorithm::decrementMultiplierOnTimeout(5.0f));
+    TEST_ASSERT_EQUAL_FLOAT(3.0f,
+        LearningAlgorithm::decrementMultiplierOnTimeout(3.25f));
 }
 
 void test_decrement_on_timeout_floors_at_one(void) {
@@ -294,14 +294,13 @@ void test_decrement_on_timeout_caps_input_too(void) {
 
 // ========== Interval-Multiplier Cap (runaway safety belt) ==========
 
-void test_max_interval_multiplier_capped_at_two_and_half(void) {
-    // Worst-case wait is bounded at 2.5 days (was 5.0). This is the safety belt
-    // for the tray-1 runaway: even a persistently false-wet sensor can only push
-    // the learned interval to 2.5x, and lowering the cap auto-rescues any
-    // runaway value loaded from flash on the first boot of new firmware.
-    TEST_ASSERT_EQUAL_FLOAT(2.5f, MAX_INTERVAL_MULTIPLIER);
-    // A multiplier the old 5.0 cap allowed (4.0x) now clamps down to the cap.
-    TEST_ASSERT_EQUAL_FLOAT(2.5f, LearningAlgorithm::clampMultiplier(4.0f));
+void test_max_interval_multiplier_is_five_days(void) {
+    // Worst-case wait stays bounded at 5.0x (~5 days). Kept at 5.0 deliberately:
+    // healthy trays (2-4.5x) must not be forced to water more often. The debounce
+    // + sustained-wet confirmation stop the runaway, not a tighter cap.
+    TEST_ASSERT_EQUAL_FLOAT(5.0f, MAX_INTERVAL_MULTIPLIER);
+    TEST_ASSERT_EQUAL_FLOAT(4.0f, LearningAlgorithm::clampMultiplier(4.0f));
+    TEST_ASSERT_EQUAL_FLOAT(5.0f, LearningAlgorithm::clampMultiplier(6.0f));
 }
 
 // ========== Rain/Soil Sensor Debounce (false-wet guard) ==========
@@ -325,6 +324,38 @@ void test_rain_debounce_threshold_and_above_reads_wet(void) {
                                            RAIN_SENSOR_DEBOUNCE_THRESHOLD));
     TEST_ASSERT_TRUE(SensorDebounce::isWet(RAIN_SENSOR_DEBOUNCE_SAMPLES,
                                            RAIN_SENSOR_DEBOUNCE_THRESHOLD));
+}
+
+// ========== Sustained-Wet Confirmation (mid-cycle flicker guard) ==========
+
+void test_wet_confirm_single_read_not_enough(void) {
+    // A lone wet read (streak 1) must NOT complete a fill — the field bug.
+    int s = SensorDebounce::nextWetStreak(0, true);
+    TEST_ASSERT_EQUAL_INT(1, s);
+    TEST_ASSERT_FALSE(
+        SensorDebounce::fillConfirmed(s, RAIN_SENSOR_CONFIRMATION_CHECKS));
+}
+
+void test_wet_confirm_consecutive_reads_confirm(void) {
+    // N consecutive wet reads confirm the fill.
+    int s = 0;
+    for (int i = 0; i < RAIN_SENSOR_CONFIRMATION_CHECKS; i++) {
+        s = SensorDebounce::nextWetStreak(s, true);
+    }
+    TEST_ASSERT_EQUAL_INT(RAIN_SENSOR_CONFIRMATION_CHECKS, s);
+    TEST_ASSERT_TRUE(
+        SensorDebounce::fillConfirmed(s, RAIN_SENSOR_CONFIRMATION_CHECKS));
+}
+
+void test_wet_confirm_dry_read_resets_streak(void) {
+    // A dry read mid-streak resets to 0, so an intermittent flicker can never
+    // accumulate enough consecutive reads to confirm.
+    int s = SensorDebounce::nextWetStreak(0, true);
+    s = SensorDebounce::nextWetStreak(s, true);   // streak 2
+    s = SensorDebounce::nextWetStreak(s, false);  // dry -> reset
+    TEST_ASSERT_EQUAL_INT(0, s);
+    TEST_ASSERT_FALSE(
+        SensorDebounce::fillConfirmed(s, RAIN_SENSOR_CONFIRMATION_CHECKS));
 }
 
 // ========== PHASE_IDLE Tests ==========
@@ -975,10 +1006,13 @@ int main(int argc, char **argv) {
     RUN_TEST(test_decrement_on_timeout_subtracts_quarter);
     RUN_TEST(test_decrement_on_timeout_floors_at_one);
     RUN_TEST(test_decrement_on_timeout_caps_input_too);
-    RUN_TEST(test_max_interval_multiplier_capped_at_two_and_half);
+    RUN_TEST(test_max_interval_multiplier_is_five_days);
     RUN_TEST(test_rain_debounce_single_stray_low_reads_dry);
     RUN_TEST(test_rain_debounce_just_below_threshold_reads_dry);
     RUN_TEST(test_rain_debounce_threshold_and_above_reads_wet);
+    RUN_TEST(test_wet_confirm_single_read_not_enough);
+    RUN_TEST(test_wet_confirm_consecutive_reads_confirm);
+    RUN_TEST(test_wet_confirm_dry_read_resets_streak);
 
     return UNITY_END();
 }

--- a/test/test_native_all.cpp
+++ b/test/test_native_all.cpp
@@ -8,6 +8,7 @@
 #include "ValveController.h"
 #include "TestConfig.h"
 #include "ValveQueueLogic.h"
+#include "SensorDebounce.h"
 
 using namespace fakeit;
 using namespace StateMachineLogic;
@@ -258,7 +259,7 @@ void test_clamp_multiplier_below_min_clamps_to_one(void) {
 
 void test_clamp_multiplier_above_max_clamps_to_cap(void) {
     // Trays we actually observed in the wild (6.5x, 7.0x) and the
-    // post-doubling worst case must all clamp to MAX_INTERVAL_MULTIPLIER (5.0).
+    // post-doubling worst case must all clamp to MAX_INTERVAL_MULTIPLIER (2.5).
     TEST_ASSERT_EQUAL_FLOAT(MAX_INTERVAL_MULTIPLIER,
         LearningAlgorithm::clampMultiplier(6.5f));
     TEST_ASSERT_EQUAL_FLOAT(MAX_INTERVAL_MULTIPLIER,
@@ -268,11 +269,11 @@ void test_clamp_multiplier_above_max_clamps_to_cap(void) {
 }
 
 void test_decrement_on_timeout_subtracts_quarter(void) {
-    // Calibrated valve at 5.00x hits TIMEOUT → 4.75x.
-    TEST_ASSERT_EQUAL_FLOAT(4.75f,
-        LearningAlgorithm::decrementMultiplierOnTimeout(5.0f));
-    TEST_ASSERT_EQUAL_FLOAT(3.0f,
-        LearningAlgorithm::decrementMultiplierOnTimeout(3.25f));
+    // Calibrated valve at 2.50x hits TIMEOUT → 2.25x.
+    TEST_ASSERT_EQUAL_FLOAT(2.25f,
+        LearningAlgorithm::decrementMultiplierOnTimeout(2.5f));
+    TEST_ASSERT_EQUAL_FLOAT(1.75f,
+        LearningAlgorithm::decrementMultiplierOnTimeout(2.0f));
 }
 
 void test_decrement_on_timeout_floors_at_one(void) {
@@ -289,6 +290,41 @@ void test_decrement_on_timeout_caps_input_too(void) {
     // (Edge case for migration paths / external callers.)
     TEST_ASSERT_EQUAL_FLOAT(MAX_INTERVAL_MULTIPLIER,
         LearningAlgorithm::decrementMultiplierOnTimeout(10.0f));
+}
+
+// ========== Interval-Multiplier Cap (runaway safety belt) ==========
+
+void test_max_interval_multiplier_capped_at_two_and_half(void) {
+    // Worst-case wait is bounded at 2.5 days (was 5.0). This is the safety belt
+    // for the tray-1 runaway: even a persistently false-wet sensor can only push
+    // the learned interval to 2.5x, and lowering the cap auto-rescues any
+    // runaway value loaded from flash on the first boot of new firmware.
+    TEST_ASSERT_EQUAL_FLOAT(2.5f, MAX_INTERVAL_MULTIPLIER);
+    // A multiplier the old 5.0 cap allowed (4.0x) now clamps down to the cap.
+    TEST_ASSERT_EQUAL_FLOAT(2.5f, LearningAlgorithm::clampMultiplier(4.0f));
+}
+
+// ========== Rain/Soil Sensor Debounce (false-wet guard) ==========
+
+void test_rain_debounce_single_stray_low_reads_dry(void) {
+    // The tray-1 root cause: a lone noise spike must NOT register as wet.
+    TEST_ASSERT_FALSE(SensorDebounce::isWet(0, RAIN_SENSOR_DEBOUNCE_THRESHOLD));
+    TEST_ASSERT_FALSE(SensorDebounce::isWet(1, RAIN_SENSOR_DEBOUNCE_THRESHOLD));
+}
+
+void test_rain_debounce_just_below_threshold_reads_dry(void) {
+    // 4 of 7 LOW is still not enough to confirm wet.
+    TEST_ASSERT_FALSE(
+        SensorDebounce::isWet(RAIN_SENSOR_DEBOUNCE_THRESHOLD - 1,
+                              RAIN_SENSOR_DEBOUNCE_THRESHOLD));
+}
+
+void test_rain_debounce_threshold_and_above_reads_wet(void) {
+    // >= threshold LOW samples -> genuinely wet.
+    TEST_ASSERT_TRUE(SensorDebounce::isWet(RAIN_SENSOR_DEBOUNCE_THRESHOLD,
+                                           RAIN_SENSOR_DEBOUNCE_THRESHOLD));
+    TEST_ASSERT_TRUE(SensorDebounce::isWet(RAIN_SENSOR_DEBOUNCE_SAMPLES,
+                                           RAIN_SENSOR_DEBOUNCE_THRESHOLD));
 }
 
 // ========== PHASE_IDLE Tests ==========
@@ -939,6 +975,10 @@ int main(int argc, char **argv) {
     RUN_TEST(test_decrement_on_timeout_subtracts_quarter);
     RUN_TEST(test_decrement_on_timeout_floors_at_one);
     RUN_TEST(test_decrement_on_timeout_caps_input_too);
+    RUN_TEST(test_max_interval_multiplier_capped_at_two_and_half);
+    RUN_TEST(test_rain_debounce_single_stray_low_reads_dry);
+    RUN_TEST(test_rain_debounce_just_below_threshold_reads_dry);
+    RUN_TEST(test_rain_debounce_threshold_and_above_reads_wet);
 
     return UNITY_END();
 }


### PR DESCRIPTION
## What & why
Tray 1 drifted to under-watering during a month-long unattended run (May 16–Jun 16). Root cause, confirmed from field logs (Loki): the soil/rain sensors flicker, and a single flickered "wet" read was taken as a real "tray full" — ending the watering cycle early and ratcheting the per-valve learning interval upward (waters less, and shorter, each cycle). The sensor trace reads `DRY` throughout cycles that nonetheless complete `✓ OK`.

## Changes
- **Rain-sensor debounce** (v1.28.0): `readRainSensor` requires a 5-of-7 majority LOW instead of a single `digitalRead`, rejecting electrical-noise spikes. Mirrors the master-overflow sensor.
- **Sustained-wet confirmation** (v1.29.0): a fill — and the cycle-start "already full" skip — completes only after `RAIN_SENSOR_CONFIRMATION_CHECKS` (3) consecutive wet reads (~300 ms), tracked per-valve (`rainWetStreak`, reset on any dry read and at phase entry). A flicker that never sustains now correctly times out → decrements the interval (waters more often). Pure helpers `SensorDebounce::nextWetStreak` / `fillConfirmed` are unit-tested.
- **Conservative tuning** (owner feedback: only Tray 1 was confirmed dry; trays 2–6 healthy at 2.25–4.5×): `MAX_INTERVAL_MULTIPLIER` kept at 5.0 and `INTERVAL_DOUBLE` at 2.0 so healthy trays keep their learned cadence — confirming both wet-detection paths is what closes the runaway, not a tighter cap.
- **Docs**: AGENTS.md "Debugging via Monitoring Logs" playbook (the `Valve N` = Tray N+1 indexing trap; the Loki filtered-query 429 gotcha → pull label-only, filter client-side); CLAUDE.md version sync.

## Behavioral impact
- Trays 2–6: unchanged cadence; the false-complete bug removed.
- Tray 1 (highest / slowest to fill): now runs its full window and settles toward daily full pours — the most the system can deliver. If still insufficient, the bottleneck is mechanical (pump head), now visible via new Grafana per-tray panels + alerts.
- Pump-on time per cycle is **unchanged** — still hard-capped by the per-valve normal/emergency timeouts (evaluated before the sensor every tick, independent of the streak), behind the independent overflow sensor + global watchdog.

## Hardware / flows affected
- 6-valve ESP32-S3 watering rig; rain sensors. No wiring changes.
- **No LittleFS / filesystem upload required** (no `data/` changes). Deploy = firmware OTA via `POST /firmware`.

## Tests run
- `pio test -e native`: **60/60** (6 new: debounce thresholds + sustained-wet confirmation streak).
- `pio run -e esp32-s3-devkitc-1`: SUCCESS (flash 89.4%).
- Adversarial safety review: **SHIP**, no blockers — pump-time bound + triple-redundant overflow protection verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)