### PR TITLE
security: scrub operator PII (telegram id / infra IP / contact) from tracked files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,16 +119,16 @@ Binary search/gradient ascent for optimal watering interval per tray. `emptyToFu
 
 **processWateringLoop()**: Watchdog → overflow/water-level checks → auto-water check → process each valve SM → sequential transitions → publish state (2s)
 
-## Cloud.ru VPS Infrastructure (45.151.30.146)
+## Cloud.ru VPS Infrastructure (203.0.113.12)
 
-All external services run on a single VPS. SSH: `ssh user1@45.151.30.146`
+All external services run on a single VPS. SSH: `ssh user1@203.0.113.12`
 
 **Nginx** (:16443, TLS) — single entry point for ESP32. Routes by URL path:
 - `/v1/telegram/*` → localhost:18085 (telegram_bot_api_proxy.py)
 - `/v1/metrics/*`, `/v1/logs/*` → localhost:18086 (esp32_metrics_proxy.py)
 - `/health` → localhost:18085
 - Config: `/etc/nginx/conf.d/water-the-flowers-proxy.conf`
-- Cert: Let's Encrypt for `water-the-flowers-proxy.aiengineerhelper.com`
+- Cert: Let's Encrypt for `water-the-flowers-proxy.example.com`
 
 **Systemd services** (on host):
 - `telegram-bot-api-proxy.service` — Telegram API forwarder (port 18085)
@@ -145,7 +145,7 @@ All external services run on a single VPS. SSH: `ssh user1@45.151.30.146`
 
 **Prometheus config**: `/home/claude-developer/monitoring/prometheus/prometheus.yml` (mounted read-only into container). Job `esp32_watering` scrapes `host.docker.internal:18086` every 15s.
 
-**Contabo VPS** (31.220.78.216) — runs 3x-ui with VLESS inbound (:8443) for Telegram API routing. Docker: `3x-ui-proxy`.
+**Contabo VPS** (203.0.113.10) — runs 3x-ui with VLESS inbound (:8443) for Telegram API routing. Docker: `3x-ui-proxy`.
 
 ## Telegram
 
@@ -153,18 +153,18 @@ All external services run on a single VPS. SSH: `ssh user1@45.151.30.146`
 
 **State JSON** (via `/api/status`): pump, sequential_mode, water_level{status,blocked}, overflow{detected,raw_value,trigger_streak}, plant_light{state,mode,schedule_on/off}, valves[]{id, state, phase, rain, timeout, learning{calibrated, auto_watering, baseline_fill_ms, last_fill_ms, empty_duration_ms, total_cycles, water_level_pct, tray_state, time_since_watering_ms, time_until_empty_ms, last_water_level_pct}}
 
-**Proxy** (v1.18.5+): Telegram Bot API proxy on Cloud.ru VPS (45.151.30.146). Proxy script: `tools/telegram_bot_api_proxy.py`, systemd: `telegram-bot-api-proxy.service`, env: `/etc/default/telegram-bot-api-proxy`. Nginx TLS termination on :16443 → localhost:18085.
+**Proxy** (v1.18.5+): Telegram Bot API proxy on Cloud.ru VPS (203.0.113.12). Proxy script: `tools/telegram_bot_api_proxy.py`, systemd: `telegram-bot-api-proxy.service`, env: `/etc/default/telegram-bot-api-proxy`. Nginx TLS termination on :16443 → localhost:18085.
 
-**SOCKS5 routing** (v1.20.0+): Telegram API is ISP-blocked on Cloud.ru. Traffic routes through a VLESS tunnel: Cloud.ru xray client (SOCKS5 on 127.0.0.1:1080) → Contabo (31.220.78.216) xray/3x-ui VLESS inbound (:8443) → api.telegram.org. Env var `SOCKS5_PROXY=127.0.0.1:1080` in `/etc/default/telegram-bot-api-proxy`. Systemd: `xray-client.service` (auto-restart, enabled on boot). Xray config: `/etc/xray/config.json`, client UUID `cloudru-telegram-proxy` in 3x-ui.
+**SOCKS5 routing** (v1.20.0+): Telegram API is ISP-blocked on Cloud.ru. Traffic routes through a VLESS tunnel: Cloud.ru xray client (SOCKS5 on 127.0.0.1:1080) → Contabo (203.0.113.10) xray/3x-ui VLESS inbound (:8443) → api.telegram.org. Env var `SOCKS5_PROXY=127.0.0.1:1080` in `/etc/default/telegram-bot-api-proxy`. Systemd: `xray-client.service` (auto-restart, enabled on boot). Xray config: `/etc/xray/config.json`, client UUID `cloudru-telegram-proxy` in 3x-ui.
 
 **Telegram not working? Checklist**:
-1. SSH to Cloud.ru: `ssh user1@45.151.30.146`
+1. SSH to Cloud.ru: `ssh user1@203.0.113.12`
 2. Check xray client: `sudo systemctl status xray-client` → restart: `sudo systemctl restart xray-client`
 3. Check proxy: `sudo systemctl status telegram-bot-api-proxy` → restart: `sudo systemctl restart telegram-bot-api-proxy`
 4. Test SOCKS5: `curl -s --socks5-hostname 127.0.0.1:1080 https://api.telegram.org/` (should return HTML)
 5. Test proxy: `curl -s "http://127.0.0.1:18085/v1/telegram/getUpdates?bot_token=<TOKEN>&offset=0&timeout=0" -H "Authorization: Bearer <TOKEN>"` (should return `{"ok":true}`)
 6. Check logs: `sudo journalctl -u xray-client -n 20` and `sudo journalctl -u telegram-bot-api-proxy -n 20`
-7. If Contabo xray is down: `docker restart 3x-ui-proxy` on Contabo (31.220.78.216)
+7. If Contabo xray is down: `docker restart 3x-ui-proxy` on Contabo (203.0.113.10)
 8. No ESP32 firmware update needed — ESP32 connects to the same nginx endpoint regardless of backend routing
 
 ## Monitoring (Prometheus + Loki + Grafana)

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ This code manages an ESP32 device for plant care. The system includes 6 watering
 - **v1.19.0**: Added Telegram command polling throttle (`TELEGRAM_COMMAND_POLL_INTERVAL_MS=1000`) so `getUpdates(timeout=0)` is not called every 100ms network loop tick. Reduces continuous `ssl_client (-76)` and `WiFiClient ERR:9` noise caused by rapid TLS reconnect churn while keeping command checks responsive.
 - **v1.18.9**: Switched recommended monitoring deployment to nginx TLS termination on `:16443` with Python proxy on localhost `127.0.0.1:18085`. This avoids direct Python TLS serving and reduces ESP32 TLS-close noise (`ssl_client -76`) while keeping auth/token logic in proxy.
 - **v1.18.8**: Added separate proxy-mode HTTP timeout (`TELEGRAM_PROXY_HTTP_TIMEOUT_MS=4000`) while keeping direct Telegram timeout at `1500ms`. Fixes repeated ESP32 SSL read timeouts when proxy->Telegram responses take longer than 1.5 seconds.
-- **v1.18.7**: Fixed monitoring proxy deployment docs for non-root service TLS key access by using service-readable cert/key copies under `/etc/telegram-bot-api-proxy`. Verified live endpoint on `https://water-the-flowers-proxy.aiengineerhelper.com:16443/health`.
-- **v1.18.6**: Updated monitoring proxy service setup docs/env examples to use `water-the-flowers-proxy.aiengineerhelper.com` certificate paths and added explicit reboot-protection verification steps (`systemctl is-enabled` + post-reboot health check).
+- **v1.18.7**: Fixed monitoring proxy deployment docs for non-root service TLS key access by using service-readable cert/key copies under `/etc/telegram-bot-api-proxy`. Verified live endpoint on `https://water-the-flowers-proxy.example.com:16443/health`.
+- **v1.18.6**: Updated monitoring proxy service setup docs/env examples to use `water-the-flowers-proxy.example.com` certificate paths and added explicit reboot-protection verification steps (`systemctl is-enabled` + post-reboot health check).
 - **v1.18.5**: Added Telegram Bot API proxy mode for ESP32 (`sendMessage` + `getUpdates`) with optional bearer auth, custom HTTPS port configuration, and monitoring-host systemd deployment files. Updated defaults/docs to avoid VPN relay conflict by using `16443` (not `15443`).
 - **v1.18.4**: just version up
 - **v1.18.3**: Made network task local-first so OTA/web API remain responsive during internet outages or Telegram restrictions. Added Telegram fast timeout + exponential cooldown to avoid repeated blocking. Limited queued Telegram notification processing to one per cycle so watering/lamp logic stays responsive even when Telegram/MQTT fail.
@@ -728,7 +728,7 @@ python3 tools/telegram_bot_api_proxy.py
 
 Health check:
 ```bash
-curl -sk https://water-the-flowers-proxy.aiengineerhelper.com:16443/health
+curl -sk https://water-the-flowers-proxy.example.com:16443/health
 ```
 
 ### systemd Setup (Custom HTTPS Port, no 443)
@@ -760,10 +760,10 @@ sudo systemctl is-enabled telegram-bot-api-proxy.service
 ```nginx
 server {
     listen 16443 ssl http2;
-    server_name water-the-flowers-proxy.aiengineerhelper.com;
+    server_name water-the-flowers-proxy.example.com;
 
-    ssl_certificate /etc/letsencrypt/live/water-the-flowers-proxy.aiengineerhelper.com/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/water-the-flowers-proxy.aiengineerhelper.com/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/water-the-flowers-proxy.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/water-the-flowers-proxy.example.com/privkey.pem;
     include /etc/letsencrypt/options-ssl-nginx.conf;
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 
@@ -794,7 +794,7 @@ sudo ufw allow 16443/tcp
 sudo reboot
 # after host is back:
 systemctl status telegram-bot-api-proxy.service --no-pager
-curl -sk https://water-the-flowers-proxy.aiengineerhelper.com:16443/health
+curl -sk https://water-the-flowers-proxy.example.com:16443/health
 ```
 
 ## 🚀 Step-by-Step Deployment

--- a/docs/superpowers/plans/2026-04-13-esp32-prometheus-monitoring.md
+++ b/docs/superpowers/plans/2026-04-13-esp32-prometheus-monitoring.md
@@ -31,7 +31,7 @@
 | `include/TelegramNotifier.h` | Add `MetricsPusher::log()` on send success/failure |
 | `include/NetworkManager.h` | Add `MetricsPusher::log()` on WiFi connect/disconnect |
 
-### Remote files (Cloud.ru VPS 45.151.30.146)
+### Remote files (Cloud.ru VPS 203.0.113.12)
 | File | Changes |
 |------|---------|
 | `/opt/iot-yc-water-the-flowers/tools/esp32_metrics_proxy.py` | Deploy new proxy script |
@@ -375,17 +375,17 @@ git commit -m "v1.20.1: add ESP32 metrics proxy for Prometheus + Loki"
 - [ ] **Step 1: Copy proxy script to server**
 
 ```bash
-scp tools/esp32_metrics_proxy.py user1@45.151.30.146:/tmp/esp32_metrics_proxy.py
-ssh user1@45.151.30.146 "sudo cp /tmp/esp32_metrics_proxy.py /opt/iot-yc-water-the-flowers/tools/esp32_metrics_proxy.py && sudo chmod 644 /opt/iot-yc-water-the-flowers/tools/esp32_metrics_proxy.py"
+scp tools/esp32_metrics_proxy.py user1@203.0.113.12:/tmp/esp32_metrics_proxy.py
+ssh user1@203.0.113.12 "sudo cp /tmp/esp32_metrics_proxy.py /opt/iot-yc-water-the-flowers/tools/esp32_metrics_proxy.py && sudo chmod 644 /opt/iot-yc-water-the-flowers/tools/esp32_metrics_proxy.py"
 ```
 
 - [ ] **Step 2: Create env file**
 
 ```bash
-ssh user1@45.151.30.146 "sudo tee /etc/default/esp32-metrics-proxy > /dev/null << 'ENVEOF'
+ssh user1@203.0.113.12 "sudo tee /etc/default/esp32-metrics-proxy > /dev/null << 'ENVEOF'
 METRICS_PROXY_HOST=127.0.0.1
 METRICS_PROXY_PORT=18086
-METRICS_PROXY_AUTH_TOKEN=774b44668b94a589c3792e6069f0df1fe75d1c927d4332075b7e58bedf2f4611
+METRICS_PROXY_AUTH_TOKEN=replace_with_long_random_token
 LOKI_PUSH_URL=http://localhost:3100/loki/api/v1/push
 ENVEOF"
 ```
@@ -395,7 +395,7 @@ Note: Reuses same auth token as Telegram proxy for simplicity (ESP32 already has
 - [ ] **Step 3: Create systemd service**
 
 ```bash
-ssh user1@45.151.30.146 "sudo tee /etc/systemd/system/esp32-metrics-proxy.service > /dev/null << 'SVCEOF'
+ssh user1@203.0.113.12 "sudo tee /etc/systemd/system/esp32-metrics-proxy.service > /dev/null << 'SVCEOF'
 [Unit]
 Description=ESP32 Metrics Proxy for Prometheus + Loki
 After=network-online.target
@@ -424,7 +424,7 @@ SVCEOF"
 - [ ] **Step 4: Enable and start the service**
 
 ```bash
-ssh user1@45.151.30.146 "sudo systemctl daemon-reload && sudo systemctl enable esp32-metrics-proxy && sudo systemctl start esp32-metrics-proxy && sudo systemctl status esp32-metrics-proxy"
+ssh user1@203.0.113.12 "sudo systemctl daemon-reload && sudo systemctl enable esp32-metrics-proxy && sudo systemctl start esp32-metrics-proxy && sudo systemctl status esp32-metrics-proxy"
 ```
 
 Expected: Active (running)
@@ -432,7 +432,7 @@ Expected: Active (running)
 - [ ] **Step 5: Verify health endpoint**
 
 ```bash
-ssh user1@45.151.30.146 "curl -s http://127.0.0.1:18086/health"
+ssh user1@203.0.113.12 "curl -s http://127.0.0.1:18086/health"
 ```
 
 Expected: `{"status": "ok"}`
@@ -447,7 +447,7 @@ Expected: `{"status": "ok"}`
 - [ ] **Step 1: Find and read current config file**
 
 ```bash
-ssh user1@45.151.30.146 "sudo grep -rl '16443' /etc/nginx/sites-enabled/ /etc/nginx/conf.d/ 2>/dev/null"
+ssh user1@203.0.113.12 "sudo grep -rl '16443' /etc/nginx/sites-enabled/ /etc/nginx/conf.d/ 2>/dev/null"
 ```
 
 This returns the config file path. Read it to get the exact filename.
@@ -459,10 +459,10 @@ Replace the single `location /` block with path-based routing. The full server b
 ```nginx
 server {
     listen 16443 ssl http2;
-    server_name water-the-flowers-proxy.aiengineerhelper.com;
+    server_name water-the-flowers-proxy.example.com;
 
-    ssl_certificate /etc/letsencrypt/live/water-the-flowers-proxy.aiengineerhelper.com/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/water-the-flowers-proxy.aiengineerhelper.com/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/water-the-flowers-proxy.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/water-the-flowers-proxy.example.com/privkey.pem;
     include /etc/letsencrypt/options-ssl-nginx.conf;
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 
@@ -514,7 +514,7 @@ Write this using `sudo tee` via SSH, replacing the existing file.
 - [ ] **Step 3: Test and reload nginx**
 
 ```bash
-ssh user1@45.151.30.146 "sudo nginx -t && sudo systemctl reload nginx"
+ssh user1@203.0.113.12 "sudo nginx -t && sudo systemctl reload nginx"
 ```
 
 Expected: `nginx: configuration file /etc/nginx/nginx.conf syntax is ok`
@@ -523,13 +523,13 @@ Expected: `nginx: configuration file /etc/nginx/nginx.conf syntax is ok`
 
 Test Telegram proxy still works:
 ```bash
-ssh user1@45.151.30.146 "curl -s -k https://localhost:16443/health"
+ssh user1@203.0.113.12 "curl -s -k https://localhost:16443/health"
 ```
 Expected: `{"status": "ok"}`
 
 Test metrics proxy through nginx:
 ```bash
-ssh user1@45.151.30.146 "curl -s -k -X POST https://localhost:16443/v1/metrics/push -H 'Authorization: Bearer 774b44668b94a589c3792e6069f0df1fe75d1c927d4332075b7e58bedf2f4611' -H 'Content-Type: application/json' -d '{\"uptime_s\":1}'"
+ssh user1@203.0.113.12 "curl -s -k -X POST https://localhost:16443/v1/metrics/push -H 'Authorization: Bearer replace_with_long_random_token' -H 'Content-Type: application/json' -d '{\"uptime_s\":1}'"
 ```
 Expected: `{"ok": true}`
 
@@ -559,18 +559,18 @@ Use `sudo tee -a` or read+modify+write via SSH.
 - [ ] **Step 2: Reload Prometheus**
 
 ```bash
-ssh user1@45.151.30.146 "sudo docker exec prometheus kill -SIGHUP 1"
+ssh user1@203.0.113.12 "sudo docker exec prometheus kill -SIGHUP 1"
 ```
 
 Or restart:
 ```bash
-ssh user1@45.151.30.146 "sudo docker restart prometheus"
+ssh user1@203.0.113.12 "sudo docker restart prometheus"
 ```
 
 - [ ] **Step 3: Verify scrape target appears**
 
 ```bash
-ssh user1@45.151.30.146 "curl -s http://localhost:9090/api/v1/targets | python3 -m json.tool | grep -A5 esp32_watering"
+ssh user1@203.0.113.12 "curl -s http://localhost:9090/api/v1/targets | python3 -m json.tool | grep -A5 esp32_watering"
 ```
 
 Expected: Target with state "up" (or "unknown" if no metrics pushed yet)
@@ -582,8 +582,8 @@ Expected: Target with state "up" (or "unknown" if no metrics pushed yet)
 - [ ] **Step 1: Push test metrics through nginx TLS**
 
 ```bash
-ssh user1@45.151.30.146 "curl -s -k -X POST https://localhost:16443/v1/metrics/push \
-  -H 'Authorization: Bearer 774b44668b94a589c3792e6069f0df1fe75d1c927d4332075b7e58bedf2f4611' \
+ssh user1@203.0.113.12 "curl -s -k -X POST https://localhost:16443/v1/metrics/push \
+  -H 'Authorization: Bearer replace_with_long_random_token' \
   -H 'Content-Type: application/json' \
   -d '{\"uptime_s\":42,\"free_heap\":180000,\"wifi_rssi\":-55,\"pump\":0,\"overflow\":0,\"overflow_streak\":0,\"water_tank_ok\":1,\"plant_light\":1,\"telegram_failures\":2,\"valves\":[{\"id\":0,\"state\":0,\"phase\":0,\"rain\":0,\"watering_s\":0,\"water_level_pct\":80,\"calibrated\":1,\"auto_watering\":1,\"interval_mult\":1.5,\"total_cycles\":10,\"time_since_ms\":7200000,\"time_until_empty_ms\":79200000,\"baseline_fill_ms\":15000,\"last_fill_ms\":14500,\"empty_duration_ms\":86400000}]}'"
 ```
@@ -592,15 +592,15 @@ Expected: `{"ok": true}`
 - [ ] **Step 2: Verify Prometheus can scrape**
 
 ```bash
-ssh user1@45.151.30.146 "curl -s http://localhost:9090/api/v1/query?query=esp32_uptime_seconds | python3 -m json.tool"
+ssh user1@203.0.113.12 "curl -s http://localhost:9090/api/v1/query?query=esp32_uptime_seconds | python3 -m json.tool"
 ```
 Expected: JSON with `"value"` containing `"42"`
 
 - [ ] **Step 3: Push test log to Loki**
 
 ```bash
-ssh user1@45.151.30.146 "curl -s -k -X POST https://localhost:16443/v1/logs/push \
-  -H 'Authorization: Bearer 774b44668b94a589c3792e6069f0df1fe75d1c927d4332075b7e58bedf2f4611' \
+ssh user1@203.0.113.12 "curl -s -k -X POST https://localhost:16443/v1/logs/push \
+  -H 'Authorization: Bearer replace_with_long_random_token' \
   -H 'Content-Type: application/json' \
   -d '{\"streams\":[{\"stream\":{\"job\":\"esp32\",\"device\":\"watering-system\",\"level\":\"info\"},\"values\":[[\"$(date +%s)000000000\",\"Test log from setup verification\"]]}]}'"
 ```
@@ -609,7 +609,7 @@ Expected: `{"ok": true}`
 - [ ] **Step 4: Verify log in Loki**
 
 ```bash
-ssh user1@45.151.30.146 "curl -s 'http://localhost:3100/loki/api/v1/query_range?query={job=\"esp32\"}&limit=5' | python3 -m json.tool | head -20"
+ssh user1@203.0.113.12 "curl -s 'http://localhost:3100/loki/api/v1/query_range?query={job=\"esp32\"}&limit=5' | python3 -m json.tool | head -20"
 ```
 Expected: JSON with the test log entry
 
@@ -1324,10 +1324,10 @@ The JSON should use Grafana dashboard model v38+ with proper datasource UIDs (us
 
 ```bash
 # First, get datasource UIDs
-ssh user1@45.151.30.146 "curl -s -u admin:admin http://localhost:3000/api/datasources | python3 -m json.tool | grep -E '\"uid\"|\"name\"|\"type\"'"
+ssh user1@203.0.113.12 "curl -s -u admin:admin http://localhost:3000/api/datasources | python3 -m json.tool | grep -E '\"uid\"|\"name\"|\"type\"'"
 
 # Import dashboard
-ssh user1@45.151.30.146 "curl -s -u admin:admin -X POST http://localhost:3000/api/dashboards/db \
+ssh user1@203.0.113.12 "curl -s -u admin:admin -X POST http://localhost:3000/api/dashboards/db \
   -H 'Content-Type: application/json' \
   -d '{\"dashboard\": $(cat tools/grafana-dashboard-esp32.json), \"overwrite\": true}'"
 ```
@@ -1336,7 +1336,7 @@ If datasource UIDs need to be hardcoded (simpler for single-server setup), repla
 
 - [ ] **Step 3: Verify dashboard loads in Grafana**
 
-Open `http://45.151.30.146:3000` in browser, navigate to the "ESP32 Watering System" dashboard. All panels should render (with data if ESP32 is pushing metrics, or empty if not yet flashed).
+Open `http://203.0.113.12:3000` in browser, navigate to the "ESP32 Watering System" dashboard. All panels should render (with data if ESP32 is pushing metrics, or empty if not yet flashed).
 
 - [ ] **Step 4: Commit**
 
@@ -1377,7 +1377,7 @@ Watch for:
 - [ ] **Step 4: Verify metrics flowing to Prometheus**
 
 ```bash
-ssh user1@45.151.30.146 "curl -s http://localhost:9090/api/v1/query?query=esp32_uptime_seconds | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d[\"data\"][\"result\"])'"
+ssh user1@203.0.113.12 "curl -s http://localhost:9090/api/v1/query?query=esp32_uptime_seconds | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d[\"data\"][\"result\"])'"
 ```
 
 Expected: Non-empty result with current uptime value
@@ -1385,7 +1385,7 @@ Expected: Non-empty result with current uptime value
 - [ ] **Step 5: Verify logs flowing to Loki**
 
 ```bash
-ssh user1@45.151.30.146 "curl -s 'http://localhost:3100/loki/api/v1/query_range?query={job=\"esp32\"}&limit=5&start=$(date -d '5 minutes ago' +%s)000000000' | python3 -m json.tool | head -30"
+ssh user1@203.0.113.12 "curl -s 'http://localhost:3100/loki/api/v1/query_range?query={job=\"esp32\"}&limit=5&start=$(date -d '5 minutes ago' +%s)000000000' | python3 -m json.tool | head -30"
 ```
 
 Expected: Boot log entries visible

--- a/docs/superpowers/specs/2026-05-05-mini-fork-design.md
+++ b/docs/superpowers/specs/2026-05-05-mini-fork-design.md
@@ -248,9 +248,9 @@ No `learning_data_*.json` (no per-valve learning).
 
 ## Cloud.ru VPS
 
-No infrastructure changes. Same Cloud.ru proxy at `https://water-the-flowers-proxy.aiengineerhelper.com:16443/` accepts any bot token.
+No infrastructure changes. Same Cloud.ru proxy at `https://water-the-flowers-proxy.example.com:16443/` accepts any bot token.
 
-- **Telegram**: register a new BotFather bot for the mini with its own token (bot is `@iot_alex_watering_1_bot`). Each device gets its own bot and its own DM thread in Telegram with the user. The user's `chat_id` (e.g., `314102923`) is the same for both bots since both DM the same person. The bot token lives in the new repo's `secret.h` (gitignored, never committed).
+- **Telegram**: register a new BotFather bot for the mini with its own token (bot is `@your_bot`). Each device gets its own bot and its own DM thread in Telegram with the user. The user's `chat_id` (e.g., `<your-telegram-chat-id>`) is the same for both bots since both DM the same person. The bot token lives in the new repo's `secret.h` (gitignored, never committed).
 - **Telegram queue resilience**: inherits mother's 16-slot `notificationQueue`. During a WiFi outage, alerts beyond 16 silently drop. Acceptable for the mini given low alert frequency (typically <10 alerts per week of normal operation).
 - **Prometheus**: add a new scrape job `esp32_watering_mini` (separate from `esp32_watering`) for clean dashboard separation. Or add a `device` label on the existing job — either works; new job is recommended.
 - **Grafana**: fork `tools/grafana-dashboard-esp32.json` into `tools/grafana-dashboard-esp32-mini.json` with simplified panels (single zone, single soil sensor, single motor; drop per-valve learning panels).


### PR DESCRIPTION
## What this does

Scrubs operator personal data and one leaked secret out of tracked **documentation** in this public repo. Non-destructive: **no history rewrite, no force-push, no merge to main**. Firmware/source (`src/`, `include/`, `config.h`, `tools/*.py`, `deploy/`) needed **no changes** — they already ship empty/placeholder defaults (`TELEGRAM_PROXY_AUTH_TOKEN=""`, `os.getenv(..., "")`), so nothing load-bearing was touched and the build is unaffected.

Every hit was in prose / example shell / example nginx blocks inside `.md` files, so placeholdering is safe and keeps the docs functional.

## Changes per file

**CLAUDE.md**
- Cloud.ru VPS IP `45.151.30.146` → `203.0.113.12` (4x)
- Contabo VPS IP `31.220.78.216` → `203.0.113.10` (3x)
- proxy domain `...aiengineerhelper.com` → `...example.com` (1x)
- (RFC5737 TEST-NET-3 doc IPs; distinct addresses kept distinct so the two-host VLESS/SOCKS5 topology still reads correctly. How-it-works prose left intact.)

**README.md**
- proxy domain `water-the-flowers-proxy.aiengineerhelper.com` → `water-the-flowers-proxy.example.com` (7x — changelog notes, health-check curls, nginx `server_name` + cert-path example block)

**docs/superpowers/plans/2026-04-13-esp32-prometheus-monitoring.md**
- Cloud.ru VPS IP `45.151.30.146` → `203.0.113.12` (23x — ssh/scp/curl deploy examples)
- proxy domain → `example.com` (3x, nginx example block)
- **leaked `METRICS_PROXY_AUTH_TOKEN` (64-hex bearer)** → `replace_with_long_random_token` (4x — env-file example + `Authorization: Bearer` curls) — see REVOKE below

**docs/superpowers/specs/2026-05-05-mini-fork-design.md**
- bot handle `@iot_alex_watering_1_bot` (embeds operator name) → `@your_bot`
- personal `chat_id` `314102923` → `<your-telegram-chat-id>`
- proxy domain → `example.com`

## REVOKE (action for operator)
- **`METRICS_PROXY_AUTH_TOKEN` / `TELEGRAM_PROXY_AUTH_TOKEN`** value `774b4466…f2f4611` (full 64-hex value is in the pre-scrub git history of this doc) was committed in cleartext. Rotate it: set a new long random token in `/etc/default/esp32-metrics-proxy` and `/etc/default/telegram-bot-api-proxy` on the Cloud.ru VPS, then restart both proxy services. This branch does not rewrite history, so the old value remains reachable in prior commits until you rotate.

## FLAGGED (left intentionally, no functional value broken)
- Nothing was left load-bearing. Because all secrets/PII lived only in `.md` docs (not in code that connects at runtime), every occurrence could be placeholdered without breaking anything. The genericized IPs/domain are documentation examples only.

## Intentionally NOT touched
- `LICENSE` line 3 — `Copyright (c) 2024 Aleksey Aksenov` is the operator's own copyright notice and is meant to stay.

## Verification
- `pii-secret-scan.sh` over the working tree is clean except `LICENSE:3` (the intended copyright line above); all IP / chat-id / domain / bot-handle / auth-token hits are gone.